### PR TITLE
Remove push to main example and add enable_pr_comments example

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ jobs:
         if: github.event_name == 'pull_request'
         uses: endorlabs/github-action@v1.1.1
         with:
+          namespace: "example" # Replace with your Endor Labs tenant namespace
           enable_pr_comments: true
           github_token: ${{ secrets.GITHUB_TOKEN }} # needed for enable_pr_comments
           scan_dependencies: true

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ jobs:
     permissions:
       id-token: write # This is required for requesting the JWT
       contents: read  # Required by actions/checkout@v3 to checkout a private repository
-      pull-requests: write # for dorny/paths-filter to read pull requests and endorctl to write pr comments
+      pull-requests: write # for endorctl to write pr comments
       issues: write        # for endorctl to write pr comments
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ on: push
 jobs:
   build-and-scan:
     permissions:
-      id-token: write # Write permission is required to request a JWT token to perform keyless authentication
-      contents: read  # Required by actions/checkout@v3 to checkout a private repository.
+      id-token: write # Write permission is required to request a json web token (JWT) to perform keyless authentication
+      contents: read  # Required by actions/checkout@v3 to checkout a private repository
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -123,10 +123,10 @@ on:
 jobs:
   ci-commons-demo-scan:
     permissions:
-      id-token: write # This is required for requesting the JWT
+      id-token: write # Required for requesting the JWT
       contents: read  # Required by actions/checkout@v3 to checkout a private repository
-      pull-requests: write # for endorctl to write pr comments
-      issues: write        # for endorctl to write pr comments
+      pull-requests: write # Required for endorctl to write pr comments
+      issues: write        # Required for endorctl to write pr comments
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
@@ -141,8 +141,8 @@ jobs:
         uses: endorlabs/github-action@v1.1.1
         with:
           namespace: "example" # Replace with your Endor Labs tenant namespace
-          enable_pr_comments: true
-          github_token: ${{ secrets.GITHUB_TOKEN }} # needed for enable_pr_comments
+          enable_pr_comments: true # Enable endorctl to write pr comments
+          github_token: ${{ secrets.GITHUB_TOKEN }} # Required for endorctl to write pr comments
           scan_dependencies: true
           scan_secrets: true
           pr: true

--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ jobs:
     permissions:
       id-token: write # This is required for requesting the JWT
       contents: read  # Required by actions/checkout@v3 to checkout a private repository
+      pull-requests: write # for dorny/paths-filter to read pull requests and endorctl to write pr comments
+      issues: write        # for endorctl to write pr comments
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
@@ -138,19 +140,11 @@ jobs:
         if: github.event_name == 'pull_request'
         uses: endorlabs/github-action@v1.1.1
         with:
-          namespace: "example"
+          enable_pr_comments: true
+          github_token: ${{ secrets.GITHUB_TOKEN }} # needed for enable_pr_comments
           scan_dependencies: true
           scan_secrets: true
-          scan_summary_output_type: "table"
           pr: true
-          pr_baseline: "main"
-      - name: Endor Labs Scan Push to main
-        if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
-        uses: endorlabs/github-action@v1.1.1
-        with:
-          namespace: "example"
-          scan_dependencies: true
-          scan_secrets: true
           scan_summary_output_type: "table"
-          pr: false
+          tags: "actor=${{ github.actor }},run-id=${{ github.run_id }}"
 ```


### PR DESCRIPTION
We rely on the daily re-scan of the baseline branch to provide the baseline instead.